### PR TITLE
Hacky way to load VHD sd images for ZXNext core

### DIFF
--- a/mbc.c
+++ b/mbc.c
@@ -404,7 +404,7 @@ static system_t system_list[] = {
   { "WONDERSWAN.COL", "EEMO" MBCSEQ,        "/media/fat/_Console/WonderSwan_",         "WonderSwan",   "wsc", },
   { "ZX81",           "EEMO" MBCSEQ,        "/media/fat/_Computer/ZX81_",              "ZX81",         "0",   },
   { "ZX81.P",         "EEMO" MBCSEQ,        "/media/fat/_Computer/ZX81_",              "ZX81",         "p",   },
-  { "ZXNEXT",         "EEMODODOMUU!mO!m" MBCSEQ, "/media/fat/_Computer/ZXNext_",       "ZXNext",       "vhd", },
+  { "ZXNEXT",         "EEMODOD!mOMUUO!m" MBCSEQ, "/media/fat/_Computer/ZXNext_",       "ZXNext",       "vhd", },
 
   // unsupported
   //{ "AMIGA",          "EEMO" MBCSEQ,        "/media/fat/_Computer/Minimig_",           "/media/fat/games/Amiga",     0, },

--- a/mbc.c
+++ b/mbc.c
@@ -388,6 +388,7 @@ static system_t system_list[] = {
   { "WONDERSWAN.COL", "EEMO" MBCSEQ,        "/media/fat/_Console/WonderSwan_",         "WonderSwan",   "wsc", },
   { "ZX81",           "EEMO" MBCSEQ,        "/media/fat/_Computer/ZX81_",              "ZX81",         "0",   },
   { "ZX81.P",         "EEMO" MBCSEQ,        "/media/fat/_Computer/ZX81_",              "ZX81",         "p",   },
+  { "ZXNEXT",         "EEMODODOMUUOEEEEEEE" MBCSEQ, "/media/fat/_Computer/ZXNext_",    "ZXNext",       "vhd", },
 
   // unsupported
   //{ "AMIGA",          "EEMO" MBCSEQ,        "/media/fat/_Computer/Minimig_",           "/media/fat/games/Amiga",     0, },


### PR DESCRIPTION
This is a "not great" way to support switching VHDs on the ZXNext platform.  It works by using the Escape key to generate pauses while the SD image is mounted.  I've done this because many ZXNext games are provided as custom SD cards (modern day physical media/ROM carts, basically) and I wanted a way to use images of the many original games I own on my MiSTer test system.

This **DEFINITELY** isn't the best way to support it, but it seems to work for me.

Edit: I'm using it with the following command

`mbc load_all /media/fat/_Computer/ZXNext_20210409.rbf /media/fat/games/ZXNext/game_name.vhd`

-Dx